### PR TITLE
Add not to Predicate

### DIFF
--- a/src/main/scala/com/al333z/antitest/TryInstances.scala
+++ b/src/main/scala/com/al333z/antitest/TryInstances.scala
@@ -1,7 +1,6 @@
 package com.al333z.antitest
 
 import cats.{Comonad, MonadError}
-
 import scala.util.{Failure, Success, Try}
 
 trait TryInstances {

--- a/src/main/scala/com/al333z/antitest/kernel/Example.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Example.scala
@@ -1,0 +1,40 @@
+package com.al333z.antitest.kernel
+
+import com.al333z.antitest.TestBuilders.testSuite
+import org.scalatest.FeatureSpec
+import com.al333z.antitest.TestBuilders._
+import com.al333z.antitest.TryInstances
+
+import scala.util.{Success, Try}
+
+class Example extends FeatureSpec with AntiTestDSL[Try] with FeatureRunner[Try] with TryInstances {
+
+  runFeature[String] {
+
+    testSuite[Try, String]("Prova")(
+      beforeAll = {
+        "String dep"
+      },
+
+      scenarios = Seq(
+        test[Try, String]("scenario di prova")(
+
+          scenario = stringDep => {
+
+            val failPredicate = Predicate.lift[Errors, String](
+              failure = Vector("This happens when predicate fail"),
+              p = string => false
+            )
+
+            val successPredicate = Predicate.lift[Errors, String](
+              failure = Vector("This happens when predicate fail"),
+              p = string => false
+            )
+
+            assertP("Una prova di Predicate")("Pippo")(failPredicate.and(successPredicate))
+          }
+      )
+      )
+    )
+  }
+}

--- a/src/main/scala/com/al333z/antitest/kernel/Example.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Example.scala
@@ -26,12 +26,13 @@ class Example extends FeatureSpec with AntiTestDSL[Try] with FeatureRunner[Try] 
               p = string => false
             )
 
-            val successPredicate = Predicate.lift[Errors, String](
-              failure = Vector("This happens when predicate fail"),
-              p = string => false
-            )
+            val notFailPredicate = Predicate.lift[Errors, String](
+              failure = Vector("This happens when predicate fail 2"),
+              p = string => fail
+            ).not
 
-            assertP("Una prova di Predicate")("Pippo")(failPredicate.and(successPredicate))
+
+            assertP("Una prova di Predicate")("Pippo")(failPredicate.and(notFailPredicate).not)
           }
       )
       )

--- a/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
@@ -1,0 +1,45 @@
+package com.al333z.antitest.kernel
+
+import cats.Semigroup
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import cats.syntax.validated._
+import cats.syntax.cartesian._
+import cats.syntax.semigroup._
+
+sealed trait Predicate[E, A] {
+  import Predicate._
+
+  def and(that: Predicate[E, A]): Predicate[E, A] = And(this, that)
+
+  def or(that: Predicate[E, A]): Predicate[E, A] = Or(this, that)
+
+  def run(a: A)(implicit sem: Semigroup[E]): Validated[E, A] = {
+    this match {
+      case Pure(fun) => fun(a)
+      case And(lp,rp) => (lp.run(a) |@| rp.run(a)).map( (_: A, _: A) => a)
+      case Or(lp,rp) => lp.run(a) match {
+        case Valid(a1) => Valid(a)
+        case Invalid(e1) => {
+          rp.run(a) match {
+            case Valid(a2) => Valid(a)
+            case Invalid(e2) => Invalid(e1 |+| e2)
+          }
+        }
+      }
+    }
+  }
+}
+
+object Predicate {
+
+  final case class And[E, A](left: Predicate[E, A], right: Predicate[E, A]) extends Predicate[E, A]
+
+  final case class Or[E, A](left: Predicate[E, A], right: Predicate[E, A]) extends Predicate[E, A]
+
+  final case class Pure[E, A](fun: A => Validated[E,A]) extends Predicate[E, A]
+
+  def apply[E, A](f: A => Validated[E, A]) = Pure(f)
+
+  def lift[E, A](failure: E, p: A => Boolean) = Pure((a: A) => if(p(a)) a.valid else failure.invalid)
+}

--- a/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
@@ -1,5 +1,4 @@
 package com.al333z.antitest.kernel
-
 import cats.Semigroup
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
@@ -14,15 +13,22 @@ sealed trait Predicate[E, A] {
 
   def or(that: Predicate[E, A]): Predicate[E, A] = Or(this, that)
 
-  def run(a: A)(implicit sem: Semigroup[E]): Validated[E, A] = {
+  def not: Predicate[E, A] = Not(this)
+
+
+  def run(a: A)(implicit sem: Semigroup[E]): Validated[E, (Boolean, E)] = {
     this match {
       case Pure(fun) => fun(a)
-      case And(lp,rp) => (lp.run(a) |@| rp.run(a)).map( (_: A, _: A) => a)
+      case Not(p) => p.run(a) match {
+        case Valid((res,e)) => Invalid(e)
+        case Invalid(e) => Valid((true,e))
+      }
+      case And(lp,rp) => (lp.run(a) |@| rp.run(a)).map( (rl,rr) => (rl._1 && rr._1, rl._2 |+| rr._2))
       case Or(lp,rp) => lp.run(a) match {
-        case Valid(a1) => Valid(a)
+        case Valid(x) => Valid(x)
         case Invalid(e1) => {
           rp.run(a) match {
-            case Valid(a2) => Valid(a)
+            case Valid(x) => Valid(x)
             case Invalid(e2) => Invalid(e1 |+| e2)
           }
         }
@@ -37,9 +43,12 @@ object Predicate {
 
   final case class Or[E, A](left: Predicate[E, A], right: Predicate[E, A]) extends Predicate[E, A]
 
-  final case class Pure[E, A](fun: A => Validated[E,A]) extends Predicate[E, A]
+  final case class Not[E, A](p: Predicate[E, A]) extends Predicate[E, A]
 
-  def apply[E, A](f: A => Validated[E, A]) = Pure(f)
+  final case class Pure[E, A](fun: A => Validated[E,(Boolean, E)]) extends Predicate[E, A]
 
-  def lift[E, A](failure: E, p: A => Boolean) = Pure((a: A) => if(p(a)) a.valid else failure.invalid)
+  def apply[E, A](f: A => Validated[E, (Boolean, E)]) = Pure(f)
+
+  def lift[E, A](failure: E, p: A => Boolean) = Pure((a: A) => if(p(a)) (true, failure).valid else failure.invalid)
 }
+


### PR DESCRIPTION
Basically I have changed return type of run() from `Validated[E, A]` to `Validaded[E, (Boolean, E)]`
There are two main reason for this.

- we are not interested to return the validated input but just to know if predicate it's true or false.
- to implement **not**  we need to know the Error message that a Successful predicate would have returned it failed 

