### PR TITLE
Implement not predicate

### DIFF
--- a/src/main/scala/com/al333z/antitest/kernel/AntiTestDSL.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/AntiTestDSL.scala
@@ -4,13 +4,15 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.implicits._
 import cats.{Eq, MonadError}
 import com.al333z.antitest.LoggerT
-
 import scala.concurrent.duration.{Duration, _}
 import scala.language.{higherKinds, postfixOps}
 
 trait AntiTestDSL[F[_]] {
 
   type Errors = Vector[String]
+
+  def predicate[A](description: String)(pred: A => Boolean): Predicate[Errors, A] =
+    Predicate.lift[Errors, A](Vector(description), pred)
 
   def given[A](description: String)(task: F[A])(
     implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], A] =
@@ -30,13 +32,14 @@ trait AntiTestDSL[F[_]] {
     else LoggerT.lift[F, Vector[String], Unit](monadError.raiseError(Vector("Assertion failed: " + description)))
   }
 
-  def assertP[A](description: String)(a: A)(predicate: Predicate[Errors, A])(
+  def assertP[A](a: A)(predicate: Predicate[Errors, A])(
     implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], Unit] = {
+
     predicate.run(a) match {
-      case Valid(_) => LoggerT[F, Vector[String], Unit](monadError.pure((Vector("Then " + description), ())))
+      case Valid((boolean, message)) => LoggerT[F, Vector[String], Unit](monadError.pure((Vector("Then " + message.mkString("\n")), ())))
       case Invalid(e) =>
         LoggerT.lift[F, Vector[String], Unit](monadError.raiseError(
-          Vector("Assertion failed: " + description) ++ e
+          Vector("Predicate failed: " + e.mkString("\n"))
         ))
     }
   }

--- a/src/main/scala/com/al333z/antitest/kernel/AntiTestDSL.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/AntiTestDSL.scala
@@ -15,59 +15,59 @@ trait AntiTestDSL[F[_]] {
     Predicate.lift[Errors, A](Vector(description), pred)
 
   def given[A](description: String)(task: F[A])(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], A] =
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, A] =
     logged("Given " + description)(task)
 
   def and[A](description: String)(task: F[A])(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], A] =
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, A] =
     logged("And " + description)(task)
 
   def when[A](description: String)(task: F[A])(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], A] =
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, A] =
     logged("When " + description)(task)
 
   def assert(description: String)(assertion: Boolean)(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], Unit] = {
-    if (assertion) LoggerT[F, Vector[String], Unit](monadError.pure((Vector("Then " + description), ())))
-    else LoggerT.lift[F, Vector[String], Unit](monadError.raiseError(Vector("Assertion failed: " + description)))
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, Unit] = {
+    if (assertion) LoggerT[F, Errors, Unit](monadError.pure((Vector("Then " + description), ())))
+    else LoggerT.lift[F, Errors, Unit](monadError.raiseError(Vector("Assertion failed: " + description)))
   }
 
   def assertP[A](a: A)(predicate: Predicate[Errors, A])(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], Unit] = {
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, Unit] = {
 
     predicate.run(a) match {
-      case Valid((boolean, message)) => LoggerT[F, Vector[String], Unit](monadError.pure((Vector("Then " + message.mkString("\n")), ())))
+      case Valid((boolean, message)) => LoggerT[F, Errors, Unit](monadError.pure((Vector("Then " + message.mkString("\n")), ())))
       case Invalid(e) =>
-        LoggerT.lift[F, Vector[String], Unit](monadError.raiseError(
+        LoggerT.lift[F, Errors, Unit](monadError.raiseError(
           Vector("Predicate failed: " + e.mkString("\n"))
         ))
     }
   }
 
   def assertF(description: String)(assertion: F[Boolean])(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], Unit] =
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, Unit] =
     assertEventuallyF(description)(assertion, 1)
 
   def assertEquals[A](description: String)(expected: A, actual: A)(
-    implicit monadError: MonadError[F, Vector[String]], eq: Eq[A]): LoggerT[F, Vector[String], Unit] = {
-    if (eq.eqv(expected, actual)) LoggerT[F, Vector[String], Unit](monadError.pure((Vector("Then " + description), ())))
-    else LoggerT.lift[F, Vector[String], Unit](monadError.raiseError(Vector("Assertion failed: expected -> " + expected + " found -> " + actual)))
+    implicit monadError: MonadError[F, Errors], eq: Eq[A]): LoggerT[F, Errors, Unit] = {
+    if (eq.eqv(expected, actual)) LoggerT[F, Errors, Unit](monadError.pure((Vector("Then " + description), ())))
+    else LoggerT.lift[F, Errors, Unit](monadError.raiseError(Vector("Assertion failed: expected -> " + expected + " found -> " + actual)))
   }
 
   def assertEventually(description: String)(assertion: () => Boolean, maxRetry: Int = 5, delay: Duration = 500 millis)(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], Unit] = {
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, Unit] = {
 
-    def retry(assertion: () => Boolean, currentRetry: Int): LoggerT[F, Vector[String], Unit] = {
+    def retry(assertion: () => Boolean, currentRetry: Int): LoggerT[F, Errors, Unit] = {
       if (assertion()) {
         val msg = "Then " + description + (if (currentRetry > 0) " (after " + currentRetry + " attempts)" else "")
-        LoggerT[F, Vector[String], Unit](monadError.pure((Vector(msg), ())))
+        LoggerT[F, Errors, Unit](monadError.pure((Vector(msg), ())))
       }
       else if (currentRetry < 5) {
         Thread.sleep(delay.toMillis) // FIXME works, but ugly
         retry(assertion, currentRetry + 1)
       }
       else
-        LoggerT.lift[F, Vector[String], Unit](
+        LoggerT.lift[F, Errors, Unit](
           monadError.raiseError(Vector("Assertion failed (after " + currentRetry + " attempts): " + description))
         )
     }
@@ -76,9 +76,9 @@ trait AntiTestDSL[F[_]] {
   }
 
   def assertEventuallyF(description: String)(assertion: F[Boolean], maxRetry: Int = 5, delay: Duration = 500 millis)(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], Unit] = {
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, Unit] = {
 
-    def retry(assertion: F[Boolean], currentRetry: Int, delay: Duration): F[(Vector[String], Unit)] = {
+    def retry(assertion: F[Boolean], currentRetry: Int, delay: Duration): F[(Errors, Unit)] = {
       assertion.flatMap { predicate: Boolean ⇒
         if (predicate) monadError.pure((Vector("Then " + description), ()))
         else if (currentRetry < maxRetry) {
@@ -86,24 +86,24 @@ trait AntiTestDSL[F[_]] {
           retry(assertion, currentRetry + 1, delay)
         }
         else
-          monadError.raiseError[(Vector[String], Unit)](Vector("Assertion failed (after " + currentRetry + " attempts): " + description))
+          monadError.raiseError[(Errors, Unit)](Vector("Assertion failed (after " + currentRetry + " attempts): " + description))
       }
     }
 
-    LoggerT[F, Vector[String], Unit](
+    LoggerT[F, Errors, Unit](
       retry(assertion, 0, delay).handleErrorWith {
         err => {
-          monadError.raiseError[(Vector[String], Unit)](Vector("Assertion failed with exception: " + description + "\n" + err.mkString("\n")))
+          monadError.raiseError[(Errors, Unit)](Vector("Assertion failed with exception: " + description + "\n" + err.mkString("\n")))
         }
       }
     )
   }
 
   private def logged[A](description: String)(task: F[A])(
-    implicit monadError: MonadError[F, Vector[String]]): LoggerT[F, Vector[String], A] = {
+    implicit monadError: MonadError[F, Errors]): LoggerT[F, Errors, A] = {
     for {
-      _ <- LoggerT[F, Vector[String], Unit](monadError.pure((Vector(description), ())))
-      res <- LoggerT.lift[F, Vector[String], A](task)
+      _ <- LoggerT[F, Errors, Unit](monadError.pure((Vector(description), ())))
+      res <- LoggerT.lift[F, Errors, A](task)
     } yield res
   }
 

--- a/src/main/scala/com/al333z/antitest/kernel/Example.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Example.scala
@@ -26,14 +26,15 @@ class Example extends FeatureSpec with AntiTestDSL[Try] with FeatureRunner[Try] 
               p = string => false
             )
 
-            val successPredicate = Predicate.lift[Errors, String](
-              failure = Vector("This happens when predicate fail"),
-              p = string => false
-            )
+            val notFailPredicate = Predicate.lift[Errors, String](
+              failure = Vector("This happens when predicate fail 2"),
+              p = string => fail
+            ).not
 
-            assertP("Una prova di Predicate")("Pippo")(failPredicate.and(successPredicate))
+
+            assertP("Una prova di Predicate")("Pippo")(failPredicate.and(notFailPredicate).not)
           }
-      )
+        )
       )
     )
   }

--- a/src/main/scala/com/al333z/antitest/kernel/Example.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Example.scala
@@ -23,7 +23,7 @@ class Example extends FeatureSpec with AntiTestDSL[Try] with FeatureRunner[Try] 
 
             val failPredicate = predicate(description = "This happens when predicate fail")((_: String) => false)
 
-            val notFailPredicate = not(predicate("This happens when predicate fail 2")((_: String) => false))
+            val notFailPredicate = not(predicate("This happens when predicate 2 fail")((_: String) => true))
 
             assertP("Pippo")(failPredicate.and(notFailPredicate))
           }

--- a/src/main/scala/com/al333z/antitest/kernel/Example.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Example.scala
@@ -1,11 +1,11 @@
 package com.al333z.antitest.kernel
 
-import com.al333z.antitest.TestBuilders.testSuite
-import org.scalatest.FeatureSpec
-import com.al333z.antitest.TestBuilders._
+import com.al333z.antitest.TestBuilders.{testSuite, _}
 import com.al333z.antitest.TryInstances
+import com.al333z.antitest.kernel.Predicate._
+import org.scalatest.FeatureSpec
 
-import scala.util.{Success, Try}
+import scala.util.Try
 
 class Example extends FeatureSpec with AntiTestDSL[Try] with FeatureRunner[Try] with TryInstances {
 
@@ -21,18 +21,11 @@ class Example extends FeatureSpec with AntiTestDSL[Try] with FeatureRunner[Try] 
 
           scenario = stringDep => {
 
-            val failPredicate = Predicate.lift[Errors, String](
-              failure = Vector("This happens when predicate fail"),
-              p = string => false
-            )
+            val failPredicate = predicate(description = "This happens when predicate fail")((_: String) => false)
 
-            val notFailPredicate = Predicate.lift[Errors, String](
-              failure = Vector("This happens when predicate fail 2"),
-              p = string => fail
-            ).not
+            val notFailPredicate = not(predicate("This happens when predicate fail 2")((_: String) => false))
 
-
-            assertP("Una prova di Predicate")("Pippo")(failPredicate.and(notFailPredicate).not)
+            assertP("Pippo")(failPredicate.and(notFailPredicate))
           }
         )
       )

--- a/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
@@ -1,30 +1,29 @@
 package com.al333z.antitest.kernel
+
 import cats.Semigroup
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
-import cats.syntax.validated._
 import cats.syntax.cartesian._
 import cats.syntax.semigroup._
+import cats.syntax.validated._
 
 sealed trait Predicate[E, A] {
+
   import Predicate._
 
   def and(that: Predicate[E, A]): Predicate[E, A] = And(this, that)
 
   def or(that: Predicate[E, A]): Predicate[E, A] = Or(this, that)
 
-  def not: Predicate[E, A] = Not(this)
-
-
   def run(a: A)(implicit sem: Semigroup[E]): Validated[E, (Boolean, E)] = {
     this match {
       case Pure(fun) => fun(a)
       case Not(p) => p.run(a) match {
-        case Valid((res,e)) => Invalid(e)
-        case Invalid(e) => Valid((true,e))
+        case Valid((res, e)) => Invalid(e)
+        case Invalid(e) => Valid((true, e))
       }
-      case And(lp,rp) => (lp.run(a) |@| rp.run(a)).map( (rl,rr) => (rl._1 && rr._1, rl._2 |+| rr._2))
-      case Or(lp,rp) => lp.run(a) match {
+      case And(lp, rp) => (lp.run(a) |@| rp.run(a)).map((rl, rr) => (rl._1 && rr._1, rl._2 |+| rr._2))
+      case Or(lp, rp) => lp.run(a) match {
         case Valid(x) => Valid(x)
         case Invalid(e1) => {
           rp.run(a) match {
@@ -39,16 +38,19 @@ sealed trait Predicate[E, A] {
 
 object Predicate {
 
+  def not[E, A](predicate: Predicate[E, A]): Predicate[E, A] = Not(predicate)
+
+  def apply[E, A](f: A => Validated[E, (Boolean, E)]) = Pure(f)
+
+  def lift[E, A](failure: E, p: A => Boolean) = Pure((a: A) => if (p(a)) (true, failure).valid else failure.invalid)
+
   final case class And[E, A](left: Predicate[E, A], right: Predicate[E, A]) extends Predicate[E, A]
 
   final case class Or[E, A](left: Predicate[E, A], right: Predicate[E, A]) extends Predicate[E, A]
 
   final case class Not[E, A](p: Predicate[E, A]) extends Predicate[E, A]
 
-  final case class Pure[E, A](fun: A => Validated[E,(Boolean, E)]) extends Predicate[E, A]
-
-  def apply[E, A](f: A => Validated[E, (Boolean, E)]) = Pure(f)
-
-  def lift[E, A](failure: E, p: A => Boolean) = Pure((a: A) => if(p(a)) (true, failure).valid else failure.invalid)
+  final case class Pure[E, A](fun: A => Validated[E, (Boolean, E)]) extends Predicate[E, A]
 }
+
 

--- a/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
+++ b/src/main/scala/com/al333z/antitest/kernel/Predicate.scala
@@ -1,5 +1,4 @@
 package com.al333z.antitest.kernel
-
 import cats.Semigroup
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
@@ -14,15 +13,22 @@ sealed trait Predicate[E, A] {
 
   def or(that: Predicate[E, A]): Predicate[E, A] = Or(this, that)
 
-  def run(a: A)(implicit sem: Semigroup[E]): Validated[E, A] = {
+  def not: Predicate[E, A] = Not(this)
+
+
+  def run(a: A)(implicit sem: Semigroup[E]): Validated[E, (Boolean, E)] = {
     this match {
       case Pure(fun) => fun(a)
-      case And(lp,rp) => (lp.run(a) |@| rp.run(a)).map( (_: A, _: A) => a)
+      case Not(p) => p.run(a) match {
+        case Valid((res,e)) => Invalid(e)
+        case Invalid(e) => Valid((true,e))
+      }
+      case And(lp,rp) => (lp.run(a) |@| rp.run(a)).map( (rl,rr) => (rl._1 && rr._1, rl._2 |+| rr._2))
       case Or(lp,rp) => lp.run(a) match {
-        case Valid(a1) => Valid(a)
+        case Valid(x) => Valid(x)
         case Invalid(e1) => {
           rp.run(a) match {
-            case Valid(a2) => Valid(a)
+            case Valid(x) => Valid(x)
             case Invalid(e2) => Invalid(e1 |+| e2)
           }
         }
@@ -37,9 +43,12 @@ object Predicate {
 
   final case class Or[E, A](left: Predicate[E, A], right: Predicate[E, A]) extends Predicate[E, A]
 
-  final case class Pure[E, A](fun: A => Validated[E,A]) extends Predicate[E, A]
+  final case class Not[E, A](p: Predicate[E, A]) extends Predicate[E, A]
 
-  def apply[E, A](f: A => Validated[E, A]) = Pure(f)
+  final case class Pure[E, A](fun: A => Validated[E,(Boolean, E)]) extends Predicate[E, A]
 
-  def lift[E, A](failure: E, p: A => Boolean) = Pure((a: A) => if(p(a)) a.valid else failure.invalid)
+  def apply[E, A](f: A => Validated[E, (Boolean, E)]) = Pure(f)
+
+  def lift[E, A](failure: E, p: A => Boolean) = Pure((a: A) => if(p(a)) (true, failure).valid else failure.invalid)
 }
+


### PR DESCRIPTION
Basically I have changed return type of run() from `Validated[E, A]` to `Validated[E, (Boolean, E)]
`.
There are two main reason for this:
- we are not interested to return the validated input but just to know if predicate it's true or false.
- to implement not we need to know the Error message that a Successful predicate would have returned it failed